### PR TITLE
updated requirements.txt to contain stable version of correct pdfmine…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 boto3==1.9.118
 requests==2.20.0
 unicodedata2==11.0.0
-pdfminer3k==1.0.4
+https://github.com/jaepil/pdfminer3k/archive/1.0.4.zip


### PR DESCRIPTION
This PR resolves [Issue 11](https://github.com/mattbierbaum/arxiv-public-datasets/issues/11), which was due to `pdfminer3k` version 1.0.4 being removed from PyPI.