### PR TITLE
add version dates to parsed records.

### DIFF
--- a/arxiv_public_data/oai_metadata.py
+++ b/arxiv_public_data/oai_metadata.py
@@ -94,6 +94,16 @@ def _record_element_all(elm, name):
     """ XML helper function for extracting text from queries with multiple nodes """
     return elm.findall('arXiv:{}'.format(name), OAI_XML_NAMESPACES)
 
+
+def _record_subelement_text(elm, name, subname):
+    """XML helper function for extracting text from queries with multiple sub-nodes"""
+    return [
+        subnode.text
+        for node in elm.findall("arXiv:{}".format(name), OAI_XML_NAMESPACES)
+        for subnode in node.findall("arXiv:{}".format(subname), OAI_XML_NAMESPACES)
+    ]
+
+
 def parse_record(elm):
     """
     Parse the XML element of a single ArXiv article into a dictionary of
@@ -122,6 +132,7 @@ def parse_record(elm):
     output['versions'] = [
         i.attrib['version'] for i in _record_element_all(elm, 'version')
     ]
+    output["versions_dates"] = _record_subelement_text(elm, "version", "date")
     return output
 
 def parse_xml_listrecords(root):


### PR DESCRIPTION
This PR add a new field containing each version date to the parsed records.

New record format: 
```diff
{
   'id': '0704.0001',
   'submitter': 'Pavel Nadolsky',
    'authors': "C. Bal\\'azs, E. L. Berger, P. M. Nadolsky, C.-P. Yuan", 'title': 'Calculation of prompt diphoton production cross sections at Tevatron and\n  LHC energies',
    'abstract': '  A fully differential calculation... ', 
    'report-no': 'ANL-HEP-PR-07-12', 
    'categories': ['hep-ph'], 
-   'versions': ['v1', 'v2']
+   'versions': ['v1', 'v2'],
+   'versions_dates': ['Mon, 2 Apr 2007 19:18:42 GMT', 'Tue, 24 Jul 2007 20:10:27 GMT']
}
```
This way you don't loose important data for each paper. 

Hope this helps.