### PR TITLE
Made changes to be able to convert to plain text

### DIFF
--- a/arxiv_public_data/fulltext.py
+++ b/arxiv_public_data/fulltext.py
@@ -166,7 +166,7 @@ def fulltext(pdffile: str, timelimit: int = TIMELIMIT):
     try:
         output = run_pdftotext(pdffile, timelimit=timelimit)
         #output = run_pdf2txt(pdffile, timelimit=timelimit)
-    except (TimeoutExpired, CalledProcessError, RuntimeError) as e:
+    except (TimeoutExpired, CalledProcessError, RuntimeError, OSError) as e:
         output = run_pdf2txt(pdffile, timelimit=timelimit)
         #output = run_pdftotext(pdffile, timelimit=timelimit)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.9.118
 requests==2.20.0
 unicodedata2==11.0.0
 https://github.com/jaepil/pdfminer3k/archive/1.0.4.zip
+pdfminer.six


### PR DESCRIPTION
Two fixes:
1) Added pdfminer.six to list of requirements to be installed
2) run_pdftotext tries to call pdftotext and produces a file not found error. Made a change to catch this error and instead run run_pdf2txt. 